### PR TITLE
Add hot reloading to react-style using react-hot?manual mode

### DIFF
--- a/App.js
+++ b/App.js
@@ -15,5 +15,3 @@ const styles = StyleSheet.create({
     color: 'red'
   }
 });
-
-// How do I update the style tag in the header with the new styles when this component changes?

--- a/index.js
+++ b/index.js
@@ -1,12 +1,24 @@
 import React from 'react';
-import App from './App';
 import StyleSheet from 'react-style';
+import App from './App';
 
 if (typeof window !== 'undefined') {
-  React.render(<App />, document.getElementById('container'));
-
   const style = document.createElement('style');
-  style.innerHTML = StyleSheet.compile().css;
-  document.head.appendChild(style);
+  function attachCompiledCSS() {
+    style.innerHTML = StyleSheet.compile().css;
+    document.head.appendChild(style);
+  }
+
+  React.render(<App />, document.getElementById('container'));
+  attachCompiledCSS();
+
+  // We are using React Hot Loader "manual" mode so we handle update ourselves:
+  if (module.hot) {
+    module.hot.accept('./App', () => {
+      const FreshApp = require('./App');
+      React.render(<FreshApp />, document.getElementById('container'));
+      attachCompiledCSS();
+    });
+  }
 }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "babel-loader": "^5.0.0",
     "react": "~0.13.2",
     "react-style": "~0.5.5"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ var config = {
   ],
   module: {
     loaders: [
-      { test: /\.jsx?$/, exclude: /node_modules/, loaders: ['react-hot', ReactStylePlugin.loader(), 'babel?{stage: 0}']}
+      { test: /\.jsx?$/, exclude: /node_modules/, loaders: ['react-hot?manual', ReactStylePlugin.loader(), 'babel?{stage: 0}']}
     ]
   }
 };


### PR DESCRIPTION
This adds hot reloading.

React Hot Loader has a “manual” mode that doesn't accept updates at component level. In this case, it is up to you to handle updates where you render the root component.

This happens to be convenient because now we have a code spot that executes whenever components change, and therefore, whenever their styles change. This means we can `compile` stylesheet again and replace it!
